### PR TITLE
ci: simplify fetching PR reference

### DIFF
--- a/.github/workflows/ai-codereview.yml
+++ b/.github/workflows/ai-codereview.yml
@@ -29,24 +29,28 @@ jobs:
               ...context.repo,
               pull_number: context.payload.pull_request.number,
             });
-            return pullRequest
+            return pullRequest.merge_commit_sha;
+
       - name: Get job name
         id: vars
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           # In that particular case it will work because we have only one job. It will also work if we'll have that job first in a row. But there no unified solution for that
-          echo "jobname=$(gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" --jq '.jobs[0] | .name')" >> $GITHUB_OUTPUT
+          echo "jobname=$(gh api "/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs" --jq '.jobs[0] | .name')" >> "$GITHUB_OUTPUT"
+
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
         with:
-          ref: ${{fromJSON(steps.pr.outputs.result).merge_commit_sha}}
+          ref: ${{ fromJSON(steps.pr.outputs.result) }}
           fetch-depth: 0
+
       - name: Checkout scripts
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4
         with:
           repository: Mirantis/ai-ci-scripts
           path: ai-ci-scripts
+
       - name: Get all changed golang files
         id: changed-golang-files
         uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c #v46.0.5
@@ -56,15 +60,19 @@ jobs:
             **zz_*.go
           files: |
             **.go
-      - uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 #v5.4.0
+
+      - name: Setup Python
+        uses: actions/setup-python@42375524e23c412d93fb67b49958b491fce71c38 #v5.4.0
         id: setup_python
         with:
           python-version: '3.12'
+
       - name: Restore cached virtualenv
         uses: actions/cache/restore@d4323d4df104b026a6aa633fdb11d772146be0bf #v4
         with:
           key: venv-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('ai-ci-scripts/ai-codereview/requirements.txt') }}
           path: .venv
+
       - name: Run ai-codereview script
         id: codereview
         if: steps.changed-golang-files.outputs.any_changed == 'true'
@@ -107,6 +115,7 @@ jobs:
                 --template-file "${PATH_TO_JINJA_TEMPLATE_FILE}"
               set -x
           done
+
       - name: AI-codereview results
         id: codereview_results
         if: steps.changed-golang-files.outputs.any_changed == 'true'
@@ -122,22 +131,26 @@ jobs:
           rich output.md
           python3 -m markdown output.md -f output.html
           echo -e "\nThere is some code review from AI. See the results [here]($JOB_URL)" >> ./summary.md
+
       - name: Upload Artifact
         id: upload_artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4
         with:
           name: ai-codereview-report
           path: output.html
+
       - name: Add link to full output
         env:
           FULL_OUTPUT: ${{ steps.upload_artifact.outputs.artifact-url }}
         run: |
           echo -e "Download full AI review output: [here]($FULL_OUTPUT)\n" >> ./summary.md
+
       - name: Saved cached virtualenv
         uses: actions/cache/save@d4323d4df104b026a6aa633fdb11d772146be0bf #v4
         with:
           key: venv-${{ runner.os }}-${{ steps.setup_python.outputs.python-version }}-${{ hashFiles('ai-ci-scripts/ai-codereview/requirements.txt') }}
           path: .venv
+
       - name: Find Comment
         uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e #v3
         id: fc
@@ -146,12 +159,14 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: 'github-actions[bot]'
           body-includes: There is some code review from AI
+
       - name: Create comment
         if: steps.changed-golang-files.outputs.any_changed == 'true' && steps.fc.outputs.comment-id == ''
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 #v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-path: summary.md
+
       - name: Update comment
         if: steps.fc.outputs.comment-id != ''
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 #v4

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -44,10 +44,10 @@ jobs:
             echo "Invalid testing configuration provided"
             exit 1
           fi
-          echo "config=$(echo -n "$config" | base64 -w 0)" >> $GITHUB_OUTPUT
+          echo "config=$(echo -n "$config" | base64 -w 0)" >> "$GITHUB_OUTPUT"
           if echo "$config" | yq e '... comments=""' | grep -q "hosted"; then
             echo "Hosted cluster deployment was triggered. Using public repository"
-            echo "public_repo=true" >> $GITHUB_OUTPUT
+            echo "public_repo=true" >> "$GITHUB_OUTPUT"
           fi
 
   lint-test:
@@ -59,7 +59,7 @@ jobs:
     outputs:
       version: ${{ steps.vars.outputs.version }}
       clusterprefix: ${{ steps.vars.outputs.clusterprefix }}
-      pr: ${{ steps.pr.outputs.result }}
+      pr_merge_commit: ${{ fromJSON(steps.pr.outputs.result) }}
     steps:
       - name: Get PR ref
         uses: actions/github-script@v7
@@ -70,30 +70,36 @@ jobs:
               ...context.repo,
               pull_number: context.payload.pull_request.number,
             });
-            return pullRequest
+            return pullRequest.merge_commit_sha;
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{fromJSON(steps.pr.outputs.result).merge_commit_sha}}
+          ref: ${{ fromJSON(steps.pr.outputs.result) }}
           fetch-depth: 0
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true # default
+
       - name: Lint
         run: GOLANGCI_LINT_TIMEOUT=10m make lint
+
       - name: Verify all generated pieces are up-to-date
         run: make generate-all && git add -N . && git diff --exit-code
+
       - name: Unit tests
         run: |
           make test
+
       - name: Get outputs
         id: vars
         run: |
           GIT_VERSION=$(git describe --tags --always)
-          echo "version=${GIT_VERSION:1}" >> $GITHUB_OUTPUT
-          echo "clusterprefix=ci-$(date +%s | cut -b6-10)" >> $GITHUB_OUTPUT
+          echo "version=${GIT_VERSION:1}" >> "$GITHUB_OUTPUT"
+          echo "clusterprefix=ci-$(date +%s | cut -b6-10)" >> "$GITHUB_OUTPUT"
 
   controller-e2etest:
     name: E2E Controller
@@ -103,18 +109,16 @@ jobs:
     concurrency:
       group: controller-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
-    outputs:
-      clusterprefix: ${{ needs.lint-test.outputs.clusterprefix }}
-      version: ${{ needs.lint-test.outputs.version }}
-      pr: ${{ needs.lint-test.outputs.pr }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{fromJSON(needs.lint-test.outputs.pr).merge_commit_sha}}
+          ref: ${{ needs.lint-test.outputs.pr_merge_commit }}
+
       - name: Setup kubectl
         uses: azure/setup-kubectl@v4
+
       - name: Run E2E tests
         env:
           GINKGO_LABEL_FILTER: 'controller'
@@ -122,6 +126,7 @@ jobs:
           VERSION: ${{ needs.lint-test.outputs.version }}
         run: |
           make test-e2e
+
       - name: Archive test results
         uses: actions/upload-artifact@v4
         if: always()
@@ -149,10 +154,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{fromJSON(needs.lint-test.outputs.pr).merge_commit_sha}}
+          ref: ${{ needs.lint-test.outputs.pr_merge_commit }}
+
       - name: Set up Buildx
         if: ${{ needs.authorize.outputs.public_repo == 'true' }}
         uses: docker/setup-buildx-action@v3
+
       - name: Login to GHCR
         if: ${{ needs.authorize.outputs.public_repo == 'true' }}
         uses: docker/login-action@v3.4.0
@@ -160,6 +167,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Build and push KCM controller image to the public repository
         if: ${{ needs.authorize.outputs.public_repo == 'true' }}
         uses: docker/build-push-action@v6
@@ -173,6 +181,7 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
       - name: Prepare and push KCM template charts to the public repository
         if: ${{ needs.authorize.outputs.public_repo == 'true' }}
         shell: bash
@@ -191,10 +200,6 @@ jobs:
     concurrency:
       group: cloud-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
-    outputs:
-      clusterprefix: ${{ needs.lint-test.outputs.clusterprefix }}
-      version: ${{ needs.lint-test.outputs.version }}
-      pr: ${{ needs.lint-test.outputs.pr }}
     env:
       AWS_REGION: us-west-2
       AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}
@@ -214,24 +219,29 @@ jobs:
         run: |
           echo "REGISTRY_REPO=oci://ghcr.io/k0rdent/kcm/charts-ci" >> $GITHUB_ENV
           echo "IMG=ghcr.io/k0rdent/kcm/controller-ci:${{ needs.lint-test.outputs.version }}" >> $GITHUB_ENV
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{fromJSON(needs.lint-test.outputs.pr).merge_commit_sha}}
+          ref: ${{ needs.lint-test.outputs.pr_merge_commit }}
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true # default
+
       - name: Setup kubectl
         uses: azure/setup-kubectl@v4
+
       - name: Load testing configuration
         if: ${{ needs.authorize.outputs.config != '' }}
         run: |
           echo -n "${{ needs.authorize.outputs.config }}" | base64 -d > test/e2e/config/config.yaml
           echo "Testing configuration was overwritten:"
           cat test/e2e/config/config.yaml
+
       - name: Run E2E tests
         env:
           GINKGO_LABEL_FILTER: 'provider:cloud'
@@ -258,10 +268,6 @@ jobs:
     concurrency:
       group: onprem-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
-    outputs:
-      clusterprefix: ${{ needs.lint-test.outputs.clusterprefix }}
-      version: ${{ needs.lint-test.outputs.version }}
-      pr: ${{ needs.lint-test.outputs.pr }}
     env:
       VSPHERE_USER: ${{ secrets.CI_VSPHERE_USER }}
       VSPHERE_PASSWORD: ${{ secrets.CI_VSPHERE_PASSWORD }}
@@ -282,24 +288,29 @@ jobs:
         run: |
           echo "REGISTRY_REPO=oci://ghcr.io/k0rdent/kcm/charts-ci" >> $GITHUB_ENV
           echo "IMG=ghcr.io/k0rdent/kcm/controller-ci:${{ needs.lint-test.outputs.version }}" >> $GITHUB_ENV
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{fromJSON(needs.lint-test.outputs.pr).merge_commit_sha}}
+          ref: ${{ needs.lint-test.outputs.pr_merge_commit }}
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true # default
+
       - name: Setup kubectl
         uses: azure/setup-kubectl@v4
+
       - name: Load testing configuration
         if: ${{ needs.authorize.outputs.config != '' }}
         run: |
           echo -n "${{ needs.authorize.outputs.config }}" | base64 -d > test/e2e/config/config.yaml
           echo "Testing configuration was overwritten:"
           cat test/e2e/config/config.yaml
+
       - name: Run E2E tests
         env:
           GINKGO_LABEL_FILTER: 'provider:onprem'
@@ -307,6 +318,7 @@ jobs:
           VERSION: ${{ needs.lint-test.outputs.version }}
         run: |
           make test-e2e
+
       - name: Archive test results
         uses: actions/upload-artifact@v4
         if: always()
@@ -324,22 +336,20 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ always() && !contains(needs.provider-cloud-e2etest.result, 'skipped') && contains(needs.lint-test.result, 'success') }}
     timeout-minutes: 15
-    outputs:
-      clusterprefix: ${{ needs.lint-test.outputs.clusterprefix }}
-      version: ${{ needs.lint-test.outputs.version }}
-      pr: ${{ needs.lint-test.outputs.pr }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{fromJSON(needs.lint-test.outputs.pr).merge_commit_sha}}
+          ref: ${{ needs.lint-test.outputs.pr_merge_commit }}
+
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
           cache: true # default
-      - name: AWS Test Resources
+
+      - name: Nuke AWS and Azure resources
         env:
           AWS_REGION: us-west-2
           AWS_ACCESS_KEY_ID: ${{ secrets.CI_AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/post-merge-push.yaml
+++ b/.github/workflows/post-merge-push.yaml
@@ -15,21 +15,26 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: Verify all generated pieces are up-to-date
         run: make generate-all && git add -N . && git diff --exit-code
+
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Login to GHCR
         uses: docker/login-action@v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Get version
         id: version
         run: |
           GIT_VERSION=$(git describe --tags --always)
-          echo "version=${GIT_VERSION#v}" >> $GITHUB_OUTPUT
+          echo "version=${GIT_VERSION#v}" >> "$GITHUB_OUTPUT"
+
       - name: Build and push KCM controller image to the public repository
         uses: docker/build-push-action@v6
         with:
@@ -42,6 +47,7 @@ jobs:
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
       - name: Prepare and push KCM template charts to the public repository
         env:
           REGISTRY_REPO: oci://ghcr.io/k0rdent/kcm/charts-ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,7 @@ jobs:
         run: |
           TAG=${{ github.ref_name }}
           echo "VERSION=${TAG#v}" >> $GITHUB_ENV
+
       - name: Set up Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -46,6 +47,7 @@ jobs:
 
       - name: Prepare KCM chart
         run: VERSION="${{ env.VERSION }}" make kcm-chart-release
+
       - name: Push charts to GHCR
         run: REGISTRY_REPO="oci://ghcr.io/k0rdent/kcm/charts" make helm-push
 

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,3 +1,4 @@
+name: Issues and PRs Stale Cron
 on:
   schedule:
     - cron: "0 10 * * *" # 10am UTC
@@ -10,7 +11,8 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - name: Stale non-active and remove marked with stale label
+        uses: actions/stale@v9
         with:
           # issues
           days-before-issue-stale: 14

--- a/.github/workflows/triage.yaml
+++ b/.github/workflows/triage.yaml
@@ -1,3 +1,4 @@
+name: Issues Triage Labels
 on:
   issues:
     types: [opened, transferred, closed, reopened, labeled, unlabeled]


### PR DESCRIPTION
Grab only merge commit hash instead of the whole
response from getting a PR.

Removed redundant jobs output from the CI WF.

Format and name all of the jobs/WFs.

