### PR TITLE
ci: improve e2e tests run and cache mgmt

### DIFF
--- a/.github/actions/check-provider-in-config/action.yml
+++ b/.github/actions/check-provider-in-config/action.yml
@@ -1,0 +1,85 @@
+name: Check Provider in Config
+description: Conditionally skip the job if a provider is missing or present in config
+
+inputs:
+  config:
+    description: Base64-encoded config (YAML)
+    required: false
+  provider:
+    description: Top-level provider key to check for (e.g., 'vsphere')
+    required: true
+  mode:
+    description: "'present' (default) or 'absent' — skip if not present or skip if present, respectively"
+    required: false
+    default: 'present'
+
+outputs:
+  skip:
+    description: Whether the job should be skipped
+    value: ${{ steps.eval.outputs.skip }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Decode and evaluate config
+      id: eval
+      shell: bash
+      run: |
+        echo "Evaluating provider: '${{ inputs.provider }}' with mode: '${{ inputs.mode }}'"
+
+        # Handle no config case
+        if [ -z "${{ inputs.config }}" ]; then
+          case "${{ inputs.mode }}" in
+            present)
+              if [ "${{ inputs.provider }}" = "vsphere" ]; then
+                echo "No config + 'present' mode + provider is vsphere → skip job"
+                echo "skip=true" >> "$GITHUB_OUTPUT"
+              else
+                echo "No config + 'present' mode + cloud provider → continue"
+                echo "skip=false" >> "$GITHUB_OUTPUT"
+              fi
+              ;;
+            absent)
+              echo "No config + 'absent' mode → assume provider is not present → continue"
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::Invalid mode: '${{ inputs.mode }}'"
+              exit 1
+              ;;
+          esac
+          exit 0
+        fi
+
+        echo "${{ inputs.config }}" | base64 -d > config.yaml
+
+        # Check if the key exists regardless of value
+        found=$(yq e "has(\"${{ inputs.provider }}\")" config.yaml)
+
+        case "${{ inputs.mode }}" in
+          present)
+            if [ "$found" = "true" ]; then
+              echo "Provider '${{ inputs.provider }}' is present — continue"
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "Provider '${{ inputs.provider }}' is NOT present — skip"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+            fi
+            ;;
+          absent)
+            if [ "$found" = "true" ]; then
+              echo "Provider '${{ inputs.provider }}' is present — skip"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "Provider '${{ inputs.provider }}' is NOT present — continue"
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+            fi
+            ;;
+          *)
+            rm config.yaml
+            echo "::error::Invalid mode: '${{ inputs.mode }}'. Use 'present' or 'absent'."
+            exit 1
+            ;;
+        esac
+
+        rm config.yaml

--- a/.github/actions/setup-go-cache/action.yml
+++ b/.github/actions/setup-go-cache/action.yml
@@ -1,0 +1,54 @@
+name: Setup Go Cache
+description: Setup Go and optionally restore Go module and linter cache, depending on USE_CACHE env var
+
+inputs:
+  go-version-file:
+    description: Path to go.mod or file containing Go version
+    required: false
+    default: 'go.mod'
+
+  include-lint-cache:
+    description: Whether to include GolangCI-Lint cache
+    required: false
+    default: 'false'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: ${{ inputs.go-version-file }}
+        cache: false
+
+    - name: Prepare cache paths
+      id: paths
+      shell: bash
+      run: |
+        echo "mod=~/go/pkg/mod" >> "$GITHUB_OUTPUT"
+        if [ "${{ inputs.include-lint-cache }}" = "true" ]; then
+          echo "lint=~/.cache/golangci-lint" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Conditionally restore Go cache
+      shell: bash
+      env:
+        USE_CACHE: ${{ env.USE_CACHE }}
+      run: |
+        echo "USE_CACHE is: ${USE_CACHE:-unset}"
+        if [ "${USE_CACHE:-true}" = "false" ]; then
+          exit 0
+        fi
+
+        echo "cache_key=${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}" >> $GITHUB_ENV
+
+    - name: Restore Go cache (actual cache step)
+      if: env.cache_key != ''
+      uses: actions/cache@v4
+      with:
+        path: |
+          ${{ steps.paths.outputs.mod }}
+          ${{ steps.paths.outputs.lint }}
+        key: ${{ env.cache_key }}
+        restore-keys: |
+          ${{ runner.os }}-go-

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -101,22 +101,10 @@ jobs:
             exit 1
           fi
 
-      - name: Setup Go
-        uses: actions/setup-go@v5
+      - name: Setup Go and Cache (with Lint)
+        uses: ./.github/actions/setup-go-cache
         with:
-          go-version-file: 'go.mod'
-          cache: false
-
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-            ~/.cache/golangci-lint
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          include-lint-cache: true
 
       - name: Lint
         run: GOLANGCI_LINT_TIMEOUT=10m make lint
@@ -164,21 +152,8 @@ jobs:
       - name: Setup kubectl
         uses: azure/setup-kubectl@v4
 
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-          cache: false
-
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+      - name: Setup Go and Cache
+        uses: ./.github/actions/setup-go-cache
 
       - name: Run E2E tests
         env:
@@ -192,7 +167,7 @@ jobs:
         if: always()
         with:
           name: support-bundles
-          path: ~/work/kcm/kcm/support-bundle-*.tar.gz"
+          path: /home/runner/work/kcm/kcm/support-bundle-*"
           retention-days: 1
           overwrite: true
 
@@ -229,16 +204,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cache Go modules
+      - name: Setup Go and Cache
         if: ${{ needs.authorize.outputs.public_repo == 'true' }}
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+        uses: ./.github/actions/setup-go-cache
 
       - name: Build and push KCM controller image to the public repository
         if: ${{ needs.authorize.outputs.public_repo == 'true' }}
@@ -287,45 +255,79 @@ jobs:
       GCP_REGION: us-east4
       PUBLIC_REPO: ${{ needs.authorize.outputs.public_repo == 'true' }}
     steps:
-      - name: Set public registry env variables
-        if: ${{ env.PUBLIC_REPO == 'true' }}
-        run: |
-          echo "REGISTRY_REPO=oci://ghcr.io/k0rdent/kcm/charts-ci" >> $GITHUB_ENV
-          echo "IMG=ghcr.io/k0rdent/kcm/controller-ci:${{ needs.lint-test.outputs.version }}" >> $GITHUB_ENV
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ needs.lint-test.outputs.pr_merge_commit }}
 
-      - name: Setup Go
-        uses: actions/setup-go@v5
+      - name: Check if vsphere-only config (skip cloud)
+        id: provider_check
+        uses: ./.github/actions/check-provider-in-config
         with:
-          go-version-file: 'go.mod'
-          cache: false
+          config: ${{ needs.authorize.outputs.config }}
+          provider: vsphere
+          mode: absent
 
-      - name: Cache Go modules
-        uses: actions/cache@v4
+      - name: Set public registry env variables
+        if: ${{ steps.provider_check.outputs.skip != 'true' && env.PUBLIC_REPO == 'true' }}
+        run: |
+          echo "REGISTRY_REPO=oci://ghcr.io/k0rdent/kcm/charts-ci" >> $GITHUB_ENV
+          echo "IMG=ghcr.io/k0rdent/kcm/controller-ci:${{ needs.lint-test.outputs.version }}" >> $GITHUB_ENV
+
+
+      - name: Check remote presence
+        id: remote_provider_check
+        uses: ./.github/actions/check-provider-in-config
         with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+          config: ${{ needs.authorize.outputs.config }}
+          provider: remote
+
+      - name: Check disk space and cleanup if too low
+        if: ${{ steps.provider_check.outputs.skip != 'true' && steps.remote_provider_check.outputs.skip != 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          BRANCH: refs/heads/${{ github.event.pull_request.base.ref }}
+        shell: bash
+        run: |
+          SPACE=$(df --output=avail -BG / | tail -1 | tr -dc '0-9')
+          echo "Available space: ${SPACE}G"
+
+          if [ "$SPACE" -lt 5 ]; then
+            echo "::warning::Low disk space (${SPACE} GiB), skipping Go cache use and cleaning caches"
+            echo "USE_CACHE=false" >> $GITHUB_ENV
+
+            echo "Cleaning up GitHub Actions caches for PR: $BRANCH"
+            cacheKeysForPR=$(gh cache list --ref "$BRANCH" --limit 100 --json id --jq '.[].id')
+
+            set +e
+            for cacheKey in $cacheKeysForPR; do
+              echo "Deleting cache with ID: $cacheKey"
+              gh cache delete "$cacheKey"
+            done
+            echo "Cache cleanup complete"
+          else
+            echo "USE_CACHE=true" >> $GITHUB_ENV
+          fi
 
       - name: Setup kubectl
+        if: steps.provider_check.outputs.skip != 'true'
         uses: azure/setup-kubectl@v4
 
+      - name: Setup Go and Cache
+        if: steps.provider_check.outputs.skip != 'true'
+        uses: ./.github/actions/setup-go-cache
+
       - name: Load testing configuration
-        if: ${{ needs.authorize.outputs.config != '' }}
+        if: ${{ steps.provider_check.outputs.skip != 'true' && needs.authorize.outputs.config != '' }}
         run: |
           echo -n "${{ needs.authorize.outputs.config }}" | base64 -d > test/e2e/config/config.yaml
           echo "Testing configuration was overwritten:"
           cat test/e2e/config/config.yaml
 
       - name: Run E2E tests
+        if: steps.provider_check.outputs.skip != 'true'
         env:
           GINKGO_LABEL_FILTER: 'provider:cloud'
           CLUSTER_DEPLOYMENT_PREFIX: ${{ needs.lint-test.outputs.clusterprefix }}
@@ -334,17 +336,17 @@ jobs:
 
       - name: Archive test results
         uses: actions/upload-artifact@v4
-        if: always()
+        if: ${{ steps.provider_check.outputs.skip != 'true' && always() }}
         with:
           name: support-bundles
-          path: ~/work/kcm/kcm/support-bundle-*.tar.gz"
+          path: /home/runner/work/kcm/kcm/support-bundle-*"
           retention-days: 1
           overwrite: true
 
   provider-onprem-e2etest:
     name: E2E On-Prem Providers
     runs-on: self-hosted
-    if: ${{ contains( github.event.pull_request.labels.*.name, 'test e2e') }}
+    if: ${{ contains( github.event.pull_request.labels.*.name, 'test e2e') && needs.authorize.outputs.config != '' }}
     needs:
       - lint-test
       - authorize
@@ -367,45 +369,45 @@ jobs:
       VSPHERE_SSH_KEY: ${{ secrets.CI_VSPHERE_SSH_KEY }}
       PUBLIC_REPO: ${{ needs.authorize.outputs.public_repo == 'true' }}
     steps:
-      - name: Set public registry env variables
-        if: ${{ env.PUBLIC_REPO == 'true' }}
-        run: |
-          echo "REGISTRY_REPO=oci://ghcr.io/k0rdent/kcm/charts-ci" >> $GITHUB_ENV
-          echo "IMG=ghcr.io/k0rdent/kcm/controller-ci:${{ needs.lint-test.outputs.version }}" >> $GITHUB_ENV
-
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ needs.lint-test.outputs.pr_merge_commit }}
 
-      - name: Setup Go
-        uses: actions/setup-go@v5
+      - name: Check vsphere presence
+        id: provider_check
+        uses: ./.github/actions/check-provider-in-config
         with:
-          go-version-file: 'go.mod'
-          cache: false
+          config: ${{ needs.authorize.outputs.config }}
+          provider: vsphere
 
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+      - name: Set public registry env variables
+        if: ${{ env.PUBLIC_REPO == 'true' }}
+        run: |
+          echo "REGISTRY_REPO=oci://ghcr.io/k0rdent/kcm/charts-ci" >> $GITHUB_ENV
+          echo "IMG=ghcr.io/k0rdent/kcm/controller-ci:${{ needs.lint-test.outputs.version }}" >> $GITHUB_ENV
+
+      - name: Setup Go and Cache
+        if: steps.provider_check.outputs.skip != 'true'
+        # we do not want to use cache on the self-hosted runner
+        env:
+          USE_CACHE: false
+        uses: ./.github/actions/setup-go-cache
 
       - name: Setup kubectl
+        if: steps.provider_check.outputs.skip != 'true'
         uses: azure/setup-kubectl@v4
 
       - name: Load testing configuration
-        if: ${{ needs.authorize.outputs.config != '' }}
+        if: ${{ steps.provider_check.outputs.skip != 'true' && needs.authorize.outputs.config != '' }}
         run: |
           echo -n "${{ needs.authorize.outputs.config }}" | base64 -d > test/e2e/config/config.yaml
           echo "Testing configuration was overwritten:"
           cat test/e2e/config/config.yaml
 
       - name: Run E2E tests
+        if: steps.provider_check.outputs.skip != 'true'
         env:
           GINKGO_LABEL_FILTER: 'provider:onprem'
           CLUSTER_DEPLOYMENT_PREFIX: ${{ needs.lint-test.outputs.clusterprefix }}
@@ -414,12 +416,16 @@ jobs:
 
       - name: Archive test results
         uses: actions/upload-artifact@v4
-        if: always()
+        if: ${{ steps.provider_check.outputs.skip != 'true' && always() }}
         with:
           name: support-bundles
-          path: ~/work/kcm/kcm/support-bundle-*.tar.gz"
+          path: /home/runner/work/kcm/kcm/support-bundle-*"
           retention-days: 1
           overwrite: true
+
+      - name: Cleanup go build and mod cache
+        if: steps.provider_check.outputs.skip != 'true'
+        run: go clean -modcache -cache
 
   cleanup:
     name: Cleanup
@@ -437,20 +443,8 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.lint-test.outputs.pr_merge_commit }}
 
-      - name: Setup Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: 'go.mod'
-          cache: false
-
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+      - name: Setup Go and Cache
+        uses: ./.github/actions/setup-go-cache
 
       - name: Nuke AWS and Azure resources
         env:

--- a/.github/workflows/cache-cleanup-on-pr-close.yml
+++ b/.github/workflows/cache-cleanup-on-pr-close.yml
@@ -1,0 +1,32 @@
+name: Cleanup Caches on Closed Pull Requests
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    name: Delete PR-specific caches
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write  # required to delete caches
+    steps:
+      - name: Delete caches for this PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          BRANCH: refs/pull/${{ github.event.pull_request.number }}/merge
+        shell: bash
+        run: |
+          echo "Fetching cache entries for PR branch: $BRANCH"
+          cacheKeysForPR=$(gh cache list --ref "$BRANCH" --limit 100 --json id --jq '.[].id')
+
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting cache entries..."
+          for cacheKey in $cacheKeysForPR; do
+            echo "Deleting cache with ID: $cacheKey"
+            gh cache delete "$cacheKey"
+          done
+          echo "Cleanup completed"

--- a/.github/workflows/post-merge-push.yaml
+++ b/.github/workflows/post-merge-push.yaml
@@ -37,15 +37,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+      - name: Setup Go and Cache
+        uses: ./.github/actions/setup-go-cache
 
       - name: Get version
         id: version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,15 +33,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
+      - name: Setup Go and Cache
+        uses: ./.github/actions/setup-go-cache
 
       - name: Prepare KCM chart
         run: VERSION="${{ steps.version.outputs.version }}" make kcm-chart-release
@@ -70,6 +63,21 @@ jobs:
       - name: Clean dirty state after preparing KCM chart
         shell: bash
         run: git checkout templates/provider/
+
+      - name: Set GORELEASER_PREVIOUS_TAG (skip rc tags)
+        shell: bash
+        run: |
+          current_tag="${{ github.ref_name }}"
+          echo "Current tag: $current_tag"
+
+          previous_tag=$(git tag --sort=-creatordate | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "$current_tag" | head -n 1)
+
+          if [ -z "$previous_tag" ]; then
+            echo "No stable previous tag found."
+          else
+            echo "Previous stable tag: $previous_tag"
+            echo "GORELEASER_PREVIOUS_TAG=$previous_tag" >> "$GITHUB_ENV"
+          fi
 
       - name: Create Release with GoReleaser
         uses: goreleaser/goreleaser-action@v6


### PR DESCRIPTION
Improves management of caches, using caches where it actually is required. Usage of cache on self-hosted runner is disabled as well as cleaning go-related caches after running e2e tests.

Checks disk space if remote provider is presented within the configuration and decides whether to use cache or not, and removes all of the available for branch caches.

Runs e2e test jobs only if they are actually required to run: skips on-prem if no vsphere is presented, and cloud if no cloud providers have been given.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
