### PR TITLE
ci: cleanup main caches periodically

### DIFF
--- a/.github/workflows/cache-cleanup-cron.yml
+++ b/.github/workflows/cache-cleanup-cron.yml
@@ -1,0 +1,41 @@
+name: Main Branch Cache Cleanup
+
+on:
+  schedule:
+    - cron: '0 3 */5 * *'  # At 03:00 on every 5th day-of-month
+  workflow_dispatch:
+
+jobs:
+  cleanup-old-caches:
+    name: Delete stale caches on main
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Delete stale caches for main branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          BRANCH: refs/heads/main
+          CUTOFF: 5 days
+        shell: bash
+        run: |
+          echo "Fetching cache entries for main branch: $BRANCH"
+          cacheInfo=$(gh cache list --ref "$BRANCH" --limit 100 --json id,lastAccessedAt --jq '.[] | "\(.id) \(.lastAccessedAt)"')
+
+          echo "Filtering caches not accessed in the last $CUTOFF"
+          cutoff=$(date -d '-$CUTOFF' +%s)
+
+          set +e
+          while read -r line; do
+            cacheId=$(echo "$line" | cut -d' ' -f1)
+            lastAccessedAt=$(echo "$line" | cut -d' ' -f2)
+            lastAccessedEpoch=$(date -d "$lastAccessedAt" +%s)
+
+            if [ "$lastAccessedEpoch" -lt "$cutoff" ]; then
+              echo "Deleting stale cache ID: $cacheId (last accessed at $lastAccessedAt)"
+              gh cache delete "$cacheId"
+            else
+              echo "Keeping recent cache ID: $cacheId (last accessed at $lastAccessedAt)"
+            fi
+          done <<< "$cacheInfo"


### PR DESCRIPTION
Adds a new WF that runs on schedule or manually to cleanup caches of the main branch that have not been accessed for the defined amount of time.

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** _(optional, `Fixes #123`)_:
